### PR TITLE
Fix BurnRate: type errors and unused-parameter warnings

### DIFF
--- a/attnroute/plugins/burnrate.py
+++ b/attnroute/plugins/burnrate.py
@@ -237,6 +237,7 @@ class BurnRatePlugin(AttnroutePlugin):
 
     def on_prompt_pre(self, prompt: str, session_state: dict) -> tuple[str, bool]:
         """Pass through — we don't modify prompts."""
+        _ = session_state
         return prompt, True
 
     def on_prompt_post(
@@ -246,6 +247,9 @@ class BurnRatePlugin(AttnroutePlugin):
         session_state: dict,
     ) -> str:
         """Inject burn rate warning if approaching limits."""
+        _ = prompt
+        _ = context_output
+        _ = session_state
         state = self.load_state()
         now = datetime.now(timezone.utc)
 
@@ -311,6 +315,8 @@ class BurnRatePlugin(AttnroutePlugin):
 
     def on_stop(self, tool_calls: list[dict], session_state: dict) -> str | None:
         """Log sample to history after each turn. Once per day, compute weekly summary."""
+        _ = tool_calls
+        _ = session_state
         now = datetime.now(timezone.utc)
         records = self._scan_window(now)
         stats = self._compute_window_stats(records)
@@ -732,7 +738,7 @@ class BurnRatePlugin(AttnroutePlugin):
             "sessions": sessions,
             "projects": projects,
             "primary_model": (
-                max(models, key=models.get) if models else "unknown"
+                max(models, key=lambda k: models[k]) if models else "unknown"
             ),
         }
 
@@ -1605,7 +1611,7 @@ class BurnRatePlugin(AttnroutePlugin):
             for r in records:
                 fam = self._get_model_family(r.get("model", ""))
                 family_counts[fam] = family_counts.get(fam, 0) + 1
-            primary_family = max(family_counts, key=family_counts.get)
+            primary_family = max(family_counts, key=lambda k: family_counts[k])
 
         pricing = self.MODEL_PRICING.get(primary_family, self.MODEL_PRICING["sonnet"])
         flat_rate = pricing["cache_create_5m"]


### PR DESCRIPTION
## Summary

Two small fixes to `attnroute/plugins/burnrate.py`. No behavior changes — these are type-safety and hygiene cleanups that silence Pyright diagnostics.

### Category 1 — Type errors on `max(dict, key=dict.get)` (2 sites)

`dict.get` returns `V | None`, which isn't compatible with `max()`'s required `SupportsRichComparison` key return type. No runtime bug in practice (both call sites iterate the dict's own keys, so `.get` never returns `None`), but Pyright flags them as `reportCallIssue` / `reportArgumentType`.

Fix: replace `key=d.get` with `key=lambda k: d[k]`. Same runtime behavior, type-sound.

Sites:
- `BurnRatePlugin._compute_window_stats` — `primary_model` lookup
- `BurnRatePlugin._estimate_cost` — `primary_family` lookup

### Category 2 — Unused-parameter warnings on interface methods (6 warnings, 3 methods)

The following `AttnroutePlugin` lifecycle methods are overridden in `BurnRatePlugin` but don't use every parameter the base-class interface provides:

- `on_prompt_pre(prompt, session_state)` — only uses `prompt`
- `on_prompt_post(prompt, context_output, session_state)` — uses none (loads state from disk via `self.load_state()`)
- `on_stop(tool_calls, session_state)` — uses neither (scans history from the log file)

Fix: add `_ = <param>` assignments at the top of each method body. This marks the parameters as intentionally unused (satisfying `reportUnusedParameter`) without renaming them to `_param`, which would diverge from the documented base-class interface in `attnroute/plugins/base.py`.

## Testing

- \`python3 -m py_compile attnroute/plugins/burnrate.py\` — clean
- Instantiated \`BurnRatePlugin()\` and called \`on_session_start\`, \`on_prompt_pre\`, \`on_prompt_post\`, \`on_stop\`, and exercised the fixed \`max()\` call paths via \`_compute_window_stats\`. All produce identical return values to pre-patch.

## Not in scope

Intentionally leaving out of this PR:
- Any change to \`PLAN_LIMITS\` constants (community-sourced, separate calibration discussion)
- Any change to how \`window_tokens\` sums cache-read tokens (the recent v1.0.2 fix addressed a related but different issue)
- Any change to \`_detect_plan_type\` logic (separate concern)

## Test plan

- [ ] \`python3 -m py_compile attnroute/plugins/burnrate.py\` passes
- [ ] Existing test suite still passes
- [ ] Pyright reports zero new diagnostics on \`burnrate.py\`